### PR TITLE
fix deprecated rust toolchain install + bump rust version

### DIFF
--- a/git-remote-gosh/Dockerfile
+++ b/git-remote-gosh/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4.2
 
 # Base builder ---------------------------
-FROM --platform=$BUILDPLATFORM rust:1.62-bullseye as rust-builder
+FROM --platform=$BUILDPLATFORM rust:1.63-bullseye as rust-builder
 
 WORKDIR /build
 
@@ -23,23 +23,20 @@ RUN \
     g++-aarch64-linux-gnu libc6-dev-arm64-cross
 RUN rustup target add \
     x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
-RUN rustup toolchain install \
-    stable-x86_64-unknown-linux-gnu stable-aarch64-unknown-linux-gnu
-RUN rustup component add rustfmt
+
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
     CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc \
     CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++ \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-    CARGO_INCREMENTAL=0
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
 
 # amd64 build ----------------------------
 FROM --platform=$BUILDPLATFORM rust-builder AS build-amd64
 RUN \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/target,sharing=private \
+    --mount=type=cache,target=/target,id=target_amd64 \
     --mount=type=bind,target=./ \
     cargo install \
     --path ./ \
@@ -51,7 +48,7 @@ FROM --platform=$BUILDPLATFORM rust-builder AS build-arm64
 RUN \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/target,sharing=private \
+    --mount=type=cache,target=/target,id=target_arm64 \
     --mount=type=bind,target=./ \
     cargo install \
     --path ./ \


### PR DESCRIPTION
**enable back incremental cargo build**

on my machine adding small change to the rust src takes ~1m to rebuild containers for two platforms

```
🚀 55s200ms via 🦀 v1.63.0 
```