### PR TITLE
web: blob onchain treshold increased

### DIFF
--- a/react-gosh/src/constants.ts
+++ b/react-gosh/src/constants.ts
@@ -1,5 +1,5 @@
 export const ZERO_COMMIT = '0000000000000000000000000000000000000000'
-export const MAX_ONCHAIN_SIZE = 56000
+export const MAX_ONCHAIN_SIZE = 64512
 
 export const EventTypes: { [key: number]: string } = {
     1: 'Pull request',


### PR DESCRIPTION
Treshold increased to 64512 bytes, 1+ kB is left for other message arguments