### PR TITLE
fix(Dockerfile): remove `www` in publisher-url

### DIFF
--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.title="Gosh" \
     com.docker.desktop.extension.api.version=">=0.2.1" \
     com.docker.desktop.extension.icon="http://icons.gosh.run/Gosh%20icon%20-%20black.svg" \
     com.docker.extension.detailed-description=${detailed_description} \
-    com.docker.extension.publisher-url="https://www.gosh.sh" \
+    com.docker.extension.publisher-url="https://gosh.sh" \
     com.docker.extension.changelog=${this_version_updates}
 
 RUN <<EOF


### PR DESCRIPTION
- Use a resolvable URL for  `com.docker.extension.publisher-url`

Mending the DNS/Cloudfront kerfuffle is real fix and I'd assume having both would improve SEO (but nmfp `¯\_(ツ)_/¯`)

<img width="1728" alt="Screenshot 2023-04-29 at 03 53 21" src="https://user-images.githubusercontent.com/10052309/235294209-9d83218c-e44d-40bd-9f99-785f8f83058b.png">

The URL is used (AFAIK) in Docker Desktop

<img width="1268" alt="Screenshot 2023-04-29 at 03 56 35" src="https://user-images.githubusercontent.com/10052309/235294293-125d9e37-85b2-4139-bfc6-9caa0a36c3d6.png">
 