### PR TITLE
Removed first remote call from output

### DIFF
--- a/gosh-dispatcher/src/main.rs
+++ b/gosh-dispatcher/src/main.rs
@@ -231,6 +231,7 @@ async fn run_binary_with_command(
         .args(args.clone())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()?;
     let mut stdin = helper
         .stdin


### PR DESCRIPTION
This can confuse users that some random remote version is displayed in the beginning of work